### PR TITLE
Expose /api/v3/site endpoint so that instances can be crawled

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -73,7 +73,7 @@ server {
     # backend
     # use the line below if you want to allow direct connections to api and pictrs
     # location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
-    location ~ ^/(feeds|nodeinfo|.well-known) {
+    location ~ ^/(feeds|nodeinfo|.well-known|api/v3/site) {
         proxy_pass http://0.0.0.0:8703;
         # Rate limit
         limit_req zone=$lemmybb_domain burst=30 nodelay;


### PR DESCRIPTION
This is necessary so that lemmybb instances can be included on https://join-lemmy.org/instances