### PR TITLE
Add feature to embed Lemmy for production use

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -25,7 +25,7 @@ steps:
     commands:
       - /root/.cargo/bin/cargo fmt -- --check
 
-  - name: cargo clippy
+  - name: cargo check
     image: rust:1.66-buster
     environment:
       CARGO_HOME: .cargo

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,14 @@ steps:
     environment:
       CARGO_HOME: .cargo
     commands:
+      - cargo check
+      - cargo check --features embed-lemmy
+
+  - name: cargo clippy
+    image: rust:1.66-buster
+    environment:
+      CARGO_HOME: .cargo
+    commands:
       - rustup component add clippy
       - cargo clippy --workspace --tests --all-targets --all-features -- -D warnings -D deprecated -D clippy::perf -D clippy::complexity -D clippy::dbg_macro
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2381,6 +2381,7 @@ dependencies = [
  "reqwest",
  "rocket",
  "rocket_dyn_templates",
+ "send_wrapper",
  "serde",
  "serde_json",
  "serial_test",
@@ -4114,6 +4115,15 @@ name = "semver"
 version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e25dfac463d778e353db5be2449d1cce89bd6fd23c9f1ea21310ce6e5a1b29c4"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ lto = "thin"
 strip = "symbols"
 debug = 0
 
+[features]
+embed-lemmy = ["lemmy_server", "send_wrapper"]
+
 [dependencies]
 log = "0.4.17"
 env_logger = { version = "0.9.1", features = ["termcolor", "humantime", "atty"], default-features = false }
@@ -19,6 +22,7 @@ lemmy_api_common = { git = "https://github.com/LemmyNet/lemmy.git" }
 lemmy_db_schema = { git = "https://github.com/LemmyNet/lemmy.git" }
 lemmy_db_views = { git = "https://github.com/LemmyNet/lemmy.git" }
 lemmy_db_views_actor = { git = "https://github.com/LemmyNet/lemmy.git" }
+lemmy_server = { git = "https://github.com/LemmyNet/lemmy.git", optional = true }
 once_cell = "1.15.0"
 anyhow = "1.0.66"
 rocket = { version = "0.5.0-rc.2", default-features = false }
@@ -35,6 +39,7 @@ rand = "0.8.5"
 deser-hjson = "1.0.2"
 json-gettext = { version = "4.0.3", default-features = false }
 tokio = "1.23.0"
+send_wrapper = { version = "0.6.0", features = ["futures"], optional = true }
 
 [dev-dependencies]
 serial_test = "0.9.0"

--- a/README.md
+++ b/README.md
@@ -169,17 +169,26 @@ Note, you must subscribe manually to remote communities, so that new activities 
 
 ## Development
 
-Execute the following command, with a Lemmy instance of your choice:
+First install dependencies and setup the database.
 ```
+sudo apt install git cargo postgresql libssl-dev pkg-config
+sudo systemctl start postgresql
+sudo -u postgres psql -c "create user lemmy with password 'password' superuser;" -U postgres
+sudo -u postgres psql -c 'create database lemmy with owner lemmy;' -U postgres
+```
+
+Then start LemmyBB with embedded Lemmy instance.
+```bash
 git clone https://github.com/LemmyNet/lemmyBB.git --recursive
 cd lemmyBB
+cargo run --features embed-lemmy
+```
+
+Then open http://127.0.0.1:1244 in your browser.
+
+It can also be useful to use a production instance as backend, for example if you notice a bug on a specific instance but don't know what causes it. To do this, run the following command with an instance of your choice.
+```
 LEMMYBB_BACKEND=https://lemmy.ml cargo run
-```
-
-You can also run a local development instance of Lemmy, either [native](https://join-lemmy.org/docs/en/contributing/local_development.html) or in [Docker](https://join-lemmy.org/docs/en/contributing/docker_development.html), and connect to it with:
-
-```
-LEMMYBB_BACKEND=http://localhost:8536 cargo run
 ```
 
 ## License

--- a/src/test.rs
+++ b/src/test.rs
@@ -37,8 +37,7 @@ fn random_string() -> String {
 async fn run_test<Fut: Future<Output = ()>>(
     test: impl Fn(asynchronous::Client, Sensitive<String>) -> Fut,
 ) {
-    let local = LocalSet::new();
-    local
+    LocalSet::new()
         .run_until(async move {
             let backend = spawn_local(lemmy_server::start_lemmy_server());
             let rocket = init_rocket().unwrap();


### PR DESCRIPTION
This change adds a new feature flag which compiles the Lemmy backend directly into the Lemmybb binary. It can make deployment easier as there is one less thing to build and deploy. It can also make development easier as you dont need to clone and run Lemmy separately.

To try it, execute `cargo run --features embed-lemmy`. Also works with `cargo build --features embed-lemmy`.

I also tried to update the installation instructions to take advantage of this. But i dont have any server to test this on, so it would be better if someone else could do it.